### PR TITLE
add .js to end of urls, makes library work directly without bundling

### DIFF
--- a/component.js
+++ b/component.js
@@ -6,7 +6,7 @@
   _ComponentAsString,
   selfClosingTags,
   getClassAsArray
-} from "./utils";
+} from "./utils.js";
 let renderCount = 0;
 class BaseComponent {
   constructor() {

--- a/router.js
+++ b/router.js
@@ -1,6 +1,6 @@
-﻿import Component, { TextComponent } from "./component";
-import { $, isDev, safeDefine } from "./utils";
-import { parseHash as _parseHash, loadHash } from "./routerUtils";
+﻿import Component, { TextComponent } from "./component.js";
+import { $, isDev, safeDefine } from "./utils.js";
+import { parseHash as _parseHash, loadHash } from "./routerUtils.js";
 const _checkHashChangeHandler = () => {
   if (typeof window.onhashchange === "function") {
     isDev


### PR DESCRIPTION
This will allow browsers that support type=module to work easily